### PR TITLE
Improve meeting creation UX and separate host tracking

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -389,12 +389,13 @@ class BotApp:
             when_local = ensure_utc(m.start_at_utc).astimezone(self.local_tz)
             host_name = await self.db.get_user_name(m.created_by) or "Unknown"
             confirmed = await self.db.count_confirmed(m.id)
+            hosts = await self.db.count_hosts(m.id)
             available = max(m.max_participants - confirmed, 0)
             text = (
                 f"<b>{when_local:%Y-%m-%d %H:%M}</b>\n"
                 f"<b>{m.topic}</b>\n"
                 f"Ведет: {host_name}\n"
-                f"Свободных мест: {available}"
+                f"Свободных мест: {available} (+ведущих: {hosts})"
             )
             keyboard = InlineKeyboardMarkup([[
                 InlineKeyboardButton(text="Записаться", callback_data=f"register:{m.id}"),
@@ -417,12 +418,13 @@ class BotApp:
             when_local = ensure_utc(m.start_at_utc).astimezone(self.local_tz)
             host_name = await self.db.get_user_name(m.created_by) or "Unknown"
             confirmed = await self.db.count_confirmed(m.id)
+            hosts = await self.db.count_hosts(m.id)
             available = max(m.max_participants - confirmed, 0)
             text = (
                 f"<b>{when_local:%Y-%m-%d %H:%M}</b>\n"
                 f"<b>{m.topic}</b>\n"
                 f"Ведет: {host_name}\n"
-                f"Свободных мест: {available}"
+                f"Свободных мест: {available} (+ведущих: {hosts})"
             )
             keyboard = InlineKeyboardMarkup([[
                 InlineKeyboardButton(text="Записаться", callback_data=f"register:{m.id}"),
@@ -522,6 +524,7 @@ class BotApp:
             host_display = "Unknown"
 
         confirmed = await self.db.count_confirmed(m.id)
+        hosts = await self.db.count_hosts(m.id)
         details_text = (
             f"<b>{m.topic}</b>\n"
             f"📝  {m.description}\n\n\n"
@@ -529,6 +532,6 @@ class BotApp:
             f"🕐 Time: {time_str} (Berlin time)\n"
             f"📍 Location {m.location or 'TBA'}\n"
             f"👤 Ведет: {host_display}\n"
-            f"👥 Идет: {confirmed} / {m.max_participants} participants"
+            f"👥 Идет: {confirmed} / {m.max_participants} participants (+ведущих: {hosts})"
         )
         await cq.message.reply_text(details_text, parse_mode="HTML")

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -379,7 +379,7 @@ class BotApp:
 
     async def cmd_meetings(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """List all upcoming meetings with register/details buttons."""
-        now_utc = datetime.utcnow().replace(tzinfo=tz.UTC)
+        now_utc = datetime.now(tz.UTC)
         meetings = await self.db.list_upcoming_meetings(now_utc)
         if not meetings:
             await update.effective_message.reply_text("No upcoming meetings.")
@@ -404,12 +404,13 @@ class BotApp:
             await update.effective_message.reply_text(text, reply_markup=keyboard, parse_mode="HTML")
 
     async def cmd_my(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        """List meetings the user is registered for."""
+        """List upcoming meetings the user is registered for."""
         user = update.effective_user
         if not user:
             return
         await self.db.get_or_create_user(user.id, user.full_name, user.username)
-        meetings = await self.db.list_user_meetings(user.id)
+        now_utc = datetime.now(tz.UTC)
+        meetings = await self.db.list_user_meetings(user.id, now_utc)
         if not meetings:
             await update.effective_message.reply_text("You have no meetings yet.")
             return

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
 from typing import Optional
 
 from dateutil import tz
@@ -25,6 +25,7 @@ from .scheduler import BotScheduler
 from .utils import ensure_utc
 from .keyboards import (
     MeetingCalendar,
+    MonthPickerKeyboard,
     TimePickerKeyboard,
     LSTEP_TRANSLATIONS,
 )
@@ -71,9 +72,10 @@ class BotApp:
     STATE_DESCRIPTION = 2
     STATE_MAX = 3
     STATE_LOCATION = 4
-    STATE_DATE = 5
-    STATE_HOUR = 6
-    STATE_MINUTE = 7
+    STATE_MONTH = 5
+    STATE_DATE = 6
+    STATE_HOUR = 7
+    STATE_MINUTE = 8
 
     def __init__(self, settings: Settings, db: Database, scheduler: BotScheduler):
         self.settings = settings
@@ -122,6 +124,9 @@ class BotApp:
                 self.STATE_LOCATION: [
                     MessageHandler(filters.TEXT & ~filters.COMMAND, self._create_meeting_location)
                 ],
+                self.STATE_MONTH: [
+                    CallbackQueryHandler(self._create_meeting_month_callback, pattern=r"^month:")
+                ],
                 self.STATE_DATE: [
                     CallbackQueryHandler(self._create_meeting_calendar_callback, pattern=r"^cbcal_")
                 ],
@@ -168,7 +173,7 @@ class BotApp:
             return self.STATE_DESCRIPTION
         context.user_data["description"] = desc
         await update.effective_message.reply_text(
-            "Принято! Описание получено.\nПожалуйста, укажи максимальное количество участников для этой встречи.\nПример: 20"
+            "Принято! Описание получено.\nПожалуйста, укажи максимальное количество участников для этой встречи, не включая ведущих.\nПример: 5"
         )
         return self.STATE_MAX
 
@@ -195,11 +200,49 @@ class BotApp:
         location = None if raw.lower() in skip_values else raw
         context.user_data["location"] = location
         received = "не указано" if not location else f"{location}"
-        # Show calendar for date selection
-        calendar, step = MeetingCalendar(calendar_id=1, min_date=date.today()).build()
+        # Show month picker for date selection
         await update.effective_message.reply_text(
             f"Принято! Место проведения: {received}.\n\n"
-            f"📅 Выбери дату встречи (выбери {LSTEP_TRANSLATIONS[step]}):",
+            f"📅 Выбери месяц встречи:",
+            reply_markup=MonthPickerKeyboard.build()
+        )
+        return self.STATE_MONTH
+
+    async def _create_meeting_month_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle month button presses for month selection."""
+        query = update.callback_query
+        if not query:
+            return self.STATE_MONTH
+        await query.answer()
+
+        parsed = MonthPickerKeyboard.parse_callback(query.data)
+        if not parsed:
+            return self.STATE_MONTH
+
+        year, month = parsed
+        context.user_data["selected_year"] = year
+        context.user_data["selected_month"] = month
+
+        # Calculate min and max dates for the calendar (only selected month)
+        tomorrow = date.today() + timedelta(days=1)
+        first_of_month = date(year, month, 1)
+        # min_date: first of selected month, but not before tomorrow
+        min_date_val = max(first_of_month, tomorrow)
+        # max_date: last day of selected month
+        if month == 12:
+            max_date_val = date(year + 1, 1, 1) - timedelta(days=1)
+        else:
+            max_date_val = date(year, month + 1, 1) - timedelta(days=1)
+
+        # Show day calendar for the selected month
+        calendar, step = MeetingCalendar(
+            calendar_id=1,
+            current_date=min_date_val,
+            min_date=min_date_val,
+            max_date=max_date_val
+        ).build()
+        await query.edit_message_text(
+            f"📅 Выбери день встречи:",
             reply_markup=calendar
         )
         return self.STATE_DATE
@@ -211,12 +254,27 @@ class BotApp:
             return self.STATE_DATE
         await query.answer()
 
-        result, key, step = MeetingCalendar(calendar_id=1, min_date=date.today()).process(query.data)
+        # Reconstruct date constraints for the selected month
+        year = context.user_data.get("selected_year")
+        month = context.user_data.get("selected_month")
+        tomorrow = date.today() + timedelta(days=1)
+        first_of_month = date(year, month, 1)
+        min_date_val = max(first_of_month, tomorrow)
+        if month == 12:
+            max_date_val = date(year + 1, 1, 1) - timedelta(days=1)
+        else:
+            max_date_val = date(year, month + 1, 1) - timedelta(days=1)
+
+        result, key, step = MeetingCalendar(
+            calendar_id=1,
+            min_date=min_date_val,
+            max_date=max_date_val
+        ).process(query.data)
 
         if not result and key:
             # User is still navigating the calendar
             await query.edit_message_text(
-                f"📅 Выбери дату встречи (выбери {LSTEP_TRANSLATIONS[step]}):",
+                f"📅 Выбери день встречи:",
                 reply_markup=key
             )
             return self.STATE_DATE

--- a/bot/models.py
+++ b/bot/models.py
@@ -61,6 +61,7 @@ class Registration(Base):
     meeting_id: Mapped[int] = mapped_column(ForeignKey("meetings.id"))
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     status: Mapped[str] = mapped_column(String(20), default=RegistrationStatus.CONFIRMED, index=True)
+    is_host: Mapped[bool] = mapped_column(default=False, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
 
     meeting: Mapped[Meeting] = relationship("Meeting", back_populates="registrations")

--- a/bot/scheduler.py
+++ b/bot/scheduler.py
@@ -77,7 +77,7 @@ class BotScheduler:
     async def _announcement_job(self, channel_id: int) -> None:
         """Compose and send an upcoming meetings digest to a channel."""
         # Minimal digest message
-        now_utc = datetime.utcnow().replace(tzinfo=tz.UTC)
+        now_utc = datetime.now(tz.UTC)
         meetings: Sequence[Meeting] = await self.db.list_upcoming_meetings(now_utc)
         if not meetings:
             text = "No upcoming meetings."

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -48,7 +48,7 @@ class Database:
     # Meetings
     async def create_meeting(self, *, host_id: int, topic: str, description: str, start_at_utc: datetime,
                               max_participants: int, location: str | None) -> Meeting:
-        """Create a new meeting and auto-register the host as confirmed."""
+        """Create a new meeting and register the host (is_host=True, doesn't count against max)."""
         async with self.session() as s:
             m = Meeting(
                 topic=topic,
@@ -60,8 +60,8 @@ class Database:
             )
             s.add(m)
             await s.flush()
-            # Auto-register host as confirmed
-            reg = Registration(meeting_id=m.id, user_id=host_id, status=RegistrationStatus.CONFIRMED)
+            # Auto-register host as confirmed (is_host=True, excluded from participant count)
+            reg = Registration(meeting_id=m.id, user_id=host_id, status=RegistrationStatus.CONFIRMED, is_host=True)
             s.add(reg)
             await s.commit()
             await s.refresh(m)
@@ -92,12 +92,25 @@ class Database:
             return res.scalars().all()
 
     async def count_confirmed(self, meeting_id: int) -> int:
-        """Return the number of confirmed registrations for the meeting."""
+        """Return the number of confirmed participants (excluding hosts)."""
         async with self.session() as s:
             res = await s.execute(
                 select(func.count()).select_from(Registration).where(
                     Registration.meeting_id == meeting_id,
                     Registration.status == RegistrationStatus.CONFIRMED,
+                    Registration.is_host == False,
+                )
+            )
+            return int(res.scalar_one())
+
+    async def count_hosts(self, meeting_id: int) -> int:
+        """Return the number of confirmed hosts for the meeting."""
+        async with self.session() as s:
+            res = await s.execute(
+                select(func.count()).select_from(Registration).where(
+                    Registration.meeting_id == meeting_id,
+                    Registration.status == RegistrationStatus.CONFIRMED,
+                    Registration.is_host == True,
                 )
             )
             return int(res.scalar_one())

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -80,13 +80,17 @@ class Database:
             )
             return res.scalars().all()
 
-    async def list_user_meetings(self, user_id: int) -> Sequence[Meeting]:
-        """List meetings the given user is confirmed to attend (or host)."""
+    async def list_user_meetings(self, user_id: int, now_utc: datetime) -> Sequence[Meeting]:
+        """List upcoming meetings the given user is confirmed to attend (or host)."""
         async with self.session() as s:
             res = await s.execute(
                 select(Meeting)
                 .join(Registration, Registration.meeting_id == Meeting.id)
-                .where(Registration.user_id == user_id, Registration.status == RegistrationStatus.CONFIRMED)
+                .where(
+                    Registration.user_id == user_id,
+                    Registration.status == RegistrationStatus.CONFIRMED,
+                    Meeting.start_at_utc >= now_utc,
+                )
                 .order_by(Meeting.start_at_utc.asc())
             )
             return res.scalars().all()


### PR DESCRIPTION
- simplified date selection
- hosts are now auto-registered with is_host=True and excluded from participant count
- /my_meetings now shows only upcoming meetings
- replaced deprecated datetime.utcnow() with datetime.now(tz.UTC) across codebase

DB migration required
`ALTER TABLE registrations ADD COLUMN is_host BOOLEAN DEFAULT 0;`
or delete gtbot.db to recreate from scratch

Fixes #8 