### PR TITLE
feat: host participant list and participant-change notifications

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -45,6 +45,11 @@ class Settings(BaseModel):
 
     log_level: str = "INFO"
 
+    # Participant change notifications: send instant DMs below this threshold,
+    # batch into a digest at/above it.
+    notify_batch_threshold: int = 10
+    notify_batch_interval_minutes: int = 30
+
     def tzinfo(self) -> zoneinfo.ZoneInfo:
         """Return ZoneInfo instance for the configured time zone."""
         return zoneinfo.ZoneInfo(self.tz)
@@ -94,6 +99,8 @@ def load_settings() -> Settings:
     announce_time = os.getenv("ANNOUNCE_TIME", "10:00")
     daily_check_time = os.getenv("DAILY_CHECK_TIME", "09:00")
     log_level = os.getenv("LOG_LEVEL", "INFO")
+    notify_batch_threshold = int(os.getenv("NOTIFY_BATCH_THRESHOLD", "10"))
+    notify_batch_interval_minutes = int(os.getenv("NOTIFY_BATCH_INTERVAL_MINUTES", "30"))
 
     return Settings(
         telegram_bot_token=token,
@@ -104,4 +111,6 @@ def load_settings() -> Settings:
         announce_time=announce_time,
         daily_check_time=daily_check_time,
         log_level=log_level,
+        notify_batch_threshold=notify_batch_threshold,
+        notify_batch_interval_minutes=notify_batch_interval_minutes,
     )

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -19,7 +19,7 @@ from telegram.ext import (
 from telegram.constants import ParseMode
 
 from .config import Settings
-from .models import Meeting
+from .models import Meeting, User, RegistrationStatus
 from .storage import Database
 from .scheduler import BotScheduler
 from .utils import ensure_utc
@@ -93,6 +93,7 @@ class BotApp:
         app.add_handler(CommandHandler("unregister", self.cmd_unregister))
         app.add_handler(CallbackQueryHandler(self.cb_register, pattern=r"^register:\d+$"))
         app.add_handler(CallbackQueryHandler(self.cb_details, pattern=r"^details:\d+$"))
+        app.add_handler(CallbackQueryHandler(self.cb_participants, pattern=r"^participants:\d+$"))
         app.add_handler(self._build_edit_meeting_handler())
         app.add_handler(CallbackQueryHandler(self.cb_cancel_meeting, pattern=r"^cancel:\d+$"))
         app.add_handler(CallbackQueryHandler(self.cb_cancel_confirm, pattern=r"^cancel_confirm:\d+$"))
@@ -220,10 +221,16 @@ class BotApp:
         can_register = include_register and not is_host and not is_participant and available > 0
         if is_host:
             buttons = [
-                InlineKeyboardButton(text="Подробности", callback_data=f"details:{meeting_id}"),
-                InlineKeyboardButton(text="Изменить", callback_data=f"edit:{meeting_id}"),
-                InlineKeyboardButton(text="Отменить", callback_data=f"cancel:{meeting_id}"),
+                [
+                    InlineKeyboardButton(text="Подробности", callback_data=f"details:{meeting_id}"),
+                    InlineKeyboardButton(text="Участники", callback_data=f"participants:{meeting_id}"),
+                ],
+                [
+                    InlineKeyboardButton(text="Изменить", callback_data=f"edit:{meeting_id}"),
+                    InlineKeyboardButton(text="Отменить", callback_data=f"cancel:{meeting_id}"),
+                ],
             ]
+            return InlineKeyboardMarkup(buttons)
         elif can_register:
             buttons = [
                 InlineKeyboardButton(text="Подробности", callback_data=f"details:{meeting_id}"),
@@ -239,6 +246,24 @@ class BotApp:
                 InlineKeyboardButton(text="Подробности", callback_data=f"details:{meeting_id}"),
             ]
         return InlineKeyboardMarkup([buttons])
+
+    @staticmethod
+    def _format_participant_list(meeting: Meeting, rows, max_participants: int) -> str:
+        """Format a numbered participant list for host display."""
+        if not rows:
+            return (
+                f"<b>Участники встречи «{meeting.topic}»</b>\n\n"
+                f"Пока никто не записался.\n"
+                f"Итого: 0 / {max_participants}"
+            )
+        lines = [f"<b>Участники встречи «{meeting.topic}»</b>\n"]
+        for i, row in enumerate(rows, start=1):
+            _, user = row
+            name = user.name or ""
+            username_part = f" (@{user.username})" if user.username else ""
+            lines.append(f"{i}. {name}{username_part}")
+        lines.append(f"\nИтого: {len(rows)} / {max_participants}")
+        return "\n".join(lines)
 
     def _build_edit_menu_keyboard(self) -> InlineKeyboardMarkup:
         """Build the inline keyboard for selecting which field to edit."""
@@ -1159,7 +1184,7 @@ class BotApp:
         user = update.effective_user
         if not user:
             return
-        await self.db.get_or_create_user(user.id, user.full_name, user.username)
+        db_user = await self.db.get_or_create_user(user.id, user.full_name, user.username)
         if not context.args:
             await update.effective_message.reply_text("Usage: /register <meeting_id>")
             return
@@ -1168,15 +1193,20 @@ class BotApp:
         except Exception:
             await update.effective_message.reply_text("Meeting id must be a number.")
             return
-        ok, msg = await self.db.register(meeting_id, user.id)
+        ok, msg, reg_status = await self.db.register(meeting_id, user.id)
         await update.effective_message.reply_text(msg)
+        if ok and reg_status == RegistrationStatus.CONFIRMED:
+            meeting = await self.db.get_meeting(meeting_id)
+            if meeting:
+                confirmed = await self.db.count_confirmed(meeting_id)
+                await self.scheduler.on_participant_change(meeting, db_user, "joined", confirmed)
 
     async def cmd_unregister(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Unregister current user from a meeting by ID."""
         user = update.effective_user
         if not user:
             return
-        await self.db.get_or_create_user(user.id, user.full_name, user.username)
+        db_user = await self.db.get_or_create_user(user.id, user.full_name, user.username)
         if not context.args:
             await update.effective_message.reply_text("Usage: /unregister <meeting_id>")
             return
@@ -1187,6 +1217,11 @@ class BotApp:
             return
         ok, msg = await self.db.unregister(meeting_id, user.id)
         await update.effective_message.reply_text(msg)
+        if ok:
+            meeting = await self.db.get_meeting(meeting_id)
+            if meeting:
+                confirmed = await self.db.count_confirmed(meeting_id)
+                await self.scheduler.on_participant_change(meeting, db_user, "left", confirmed)
 
     # ========== Callback Query Handlers ==========
 
@@ -1199,7 +1234,7 @@ class BotApp:
         user = update.effective_user
         if not user:
             return
-        await self.db.get_or_create_user(user.id, user.full_name, user.username)
+        db_user = await self.db.get_or_create_user(user.id, user.full_name, user.username)
         data = cq.data or ""
         try:
             _, meeting_id_str = data.split(":", 1)
@@ -1207,8 +1242,13 @@ class BotApp:
         except Exception:
             await cq.message.reply_text("Invalid registration request.")
             return
-        ok, msg = await self.db.register(meeting_id, user.id)
+        ok, msg, reg_status = await self.db.register(meeting_id, user.id)
         await cq.message.reply_text(msg)
+        if ok and reg_status == RegistrationStatus.CONFIRMED:
+            meeting = await self.db.get_meeting(meeting_id)
+            if meeting:
+                confirmed = await self.db.count_confirmed(meeting_id)
+                await self.scheduler.on_participant_change(meeting, db_user, "joined", confirmed)
 
     async def cb_details(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle inline 'Подробности' button presses to show meeting details."""
@@ -1257,6 +1297,38 @@ class BotApp:
             f"👥 Идет: {confirmed} / {m.max_participants} participants (+ведущих: {hosts})"
         )
         await _reply_with_card(cq.message, details_text, m.photo_file_id)
+
+    async def cb_participants(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Show the host a numbered list of confirmed participants for their meeting."""
+        cq = update.callback_query
+        if not cq:
+            return
+        await cq.answer()
+
+        user = update.effective_user
+        if not user:
+            return
+
+        data = cq.data or ""
+        try:
+            _, meeting_id_str = data.split(":", 1)
+            meeting_id = int(meeting_id_str)
+        except Exception:
+            await cq.message.reply_text("Ошибка: неверный запрос.")
+            return
+
+        meeting = await self.db.get_meeting(meeting_id)
+        if not meeting:
+            await cq.message.reply_text("Встреча не найдена.")
+            return
+
+        if meeting.created_by != user.id:
+            await cq.message.reply_text("Список участников доступен только организатору встречи.")
+            return
+
+        rows = await self.db.list_confirmed_participants(meeting_id)
+        text = self._format_participant_list(meeting, rows, meeting.max_participants)
+        await cq.message.reply_text(text, parse_mode="HTML")
 
     async def cb_cancel_meeting(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle inline 'Отменить' button presses - show confirmation."""
@@ -1445,6 +1517,11 @@ class BotApp:
                 + " отменено."
             )
             await cq.edit_message_text(text, parse_mode="HTML")
+            if meeting:
+                db_user = await self.db.get_user(user.id)
+                if db_user:
+                    confirmed = await self.db.count_confirmed(meeting_id)
+                    await self.scheduler.on_participant_change(meeting, db_user, "left", confirmed)
         else:
             await cq.edit_message_text(f"Не удалось отменить участие: {msg}")
 

--- a/bot/scheduler.py
+++ b/bot/scheduler.py
@@ -2,16 +2,23 @@
 from __future__ import annotations
 
 import calendar
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
-from typing import Callable, Awaitable, Sequence
+from typing import Callable, Awaitable, Literal, Sequence
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
 from dateutil import tz
+from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup
 
 from .storage import Database
-from .models import Meeting
+from .models import Meeting, User
 from .utils import ensure_utc
+
+log = logging.getLogger(__name__)
 
 # Days before the second (and further) announce day to start the coverage window.
 # E.g. announce on 15th → cover meetings from 18th onward.
@@ -121,16 +128,41 @@ def _split_messages(header: str, cards: list[str], max_len: int = _TG_MAX_MESSAG
     return messages
 
 
+@dataclass
+class _ParticipantEvent:
+    user_name: str
+    event: Literal["joined", "left"]
+    at: datetime = field(default_factory=datetime.utcnow)
+
+
+def _display_name(user: User) -> str:
+    """Format a display name, appending @username when available."""
+    if user.username:
+        return f"{user.name} (@{user.username})" if user.name else f"@{user.username}"
+    return user.name or f"User#{user.id}"
+
+
 class BotScheduler:
     """Wrapper around AsyncIOScheduler to manage bot jobs."""
 
-    def __init__(self, db: Database, timezone, send_channel_card: Callable[[int, str, str | None], Awaitable[None]]):
+    def __init__(
+        self,
+        db: Database,
+        timezone,
+        send_channel_card: Callable[[int, str, str | None], Awaitable[None]],
+        *,
+        bot: Bot | None = None,
+        notify_threshold: int = 10,
+    ):
         self.db = db
         self.scheduler = AsyncIOScheduler(timezone=timezone)
         self._tz = timezone
         self._send_channel_card = send_channel_card
+        self._bot = bot
+        self._notify_threshold = notify_threshold
         self._announce_days: list[int] = [1, 15]
         self._channel_id: int | None = None
+        self._pending_events: dict[int, list[_ParticipantEvent]] = defaultdict(list)
 
     def start(self) -> None:
         """Start the underlying scheduler if not already running."""
@@ -202,6 +234,96 @@ class BotScheduler:
         for m in meetings:
             participants = await self.db.count_confirmed(m.id)
             await self._send_channel_card(channel_id, _format_meeting_card(m, participants, self._tz), m.photo_file_id)
+
+    def schedule_host_notifications(self, interval_minutes: int) -> None:
+        """Register a periodic job to flush batched participant-change DMs to hosts."""
+        if not self._bot:
+            return
+        self.scheduler.add_job(
+            self._flush_pending_notifications,
+            trigger=IntervalTrigger(minutes=interval_minutes),
+            id="host_notifications_flush",
+            replace_existing=True,
+        )
+
+    async def on_participant_change(
+        self,
+        meeting: Meeting,
+        user: User,
+        event: Literal["joined", "left"],
+        confirmed_count: int,
+    ) -> None:
+        """Route a signup or cancellation to instant DM or the batch queue."""
+        if not self._bot:
+            return
+        if confirmed_count < self._notify_threshold:
+            await self._send_instant_notification(meeting, user, event, confirmed_count)
+        else:
+            self._pending_events[meeting.id].append(
+                _ParticipantEvent(user_name=_display_name(user), event=event)
+            )
+
+    async def _send_instant_notification(
+        self,
+        meeting: Meeting,
+        user: User,
+        event: Literal["joined", "left"],
+        confirmed_count: int,
+    ) -> None:
+        icon = "➕" if event == "joined" else "➖"
+        action = "записалась на" if event == "joined" else "отменила участие в"
+        text = (
+            f"{icon} <b>{_display_name(user)}</b> {action} «{meeting.topic}»\n"
+            f"Участников: {confirmed_count} / {meeting.max_participants}"
+        )
+        await self._send_host_dm(meeting.created_by, text)
+
+    async def _flush_pending_notifications(self) -> None:
+        """Send batched digest DMs for all meetings with queued events, then clear the queue."""
+        if not self._pending_events:
+            return
+        # Snapshot and clear atomically before any awaits to avoid double-sending on slow runs
+        pending = dict(self._pending_events)
+        self._pending_events.clear()
+
+        for meeting_id, events in pending.items():
+            if not events:
+                continue
+            meeting = await self.db.get_meeting(meeting_id)
+            if not meeting or meeting.canceled_at:
+                continue
+
+            joined = sum(1 for e in events if e.event == "joined")
+            left = sum(1 for e in events if e.event == "left")
+            confirmed = await self.db.count_confirmed(meeting_id)
+
+            parts = []
+            if joined:
+                parts.append(f"+{joined} записались")
+            if left:
+                parts.append(f"−{left} отменили")
+
+            text = (
+                f"📊 <b>Обновление участников — «{meeting.topic}»</b>\n"
+                f"{', '.join(parts)}\n"
+                f"Сейчас: {confirmed} / {meeting.max_participants}"
+            )
+            keyboard = InlineKeyboardMarkup([[
+                InlineKeyboardButton("Посмотреть список", callback_data=f"participants:{meeting_id}")
+            ]])
+            await self._send_host_dm(meeting.created_by, text, reply_markup=keyboard)
+
+    async def _send_host_dm(self, host_id: int, text: str, *, reply_markup=None) -> None:
+        """Send a DM to the meeting host, logging and suppressing send errors."""
+        try:
+            await self._bot.send_message(
+                chat_id=host_id,
+                text=text,
+                parse_mode="HTML",
+                reply_markup=reply_markup,
+            )
+        except Exception:
+            log.warning("Failed to send DM to host %d", host_id)
 
     async def maybe_announce_new_meeting(self, meeting: Meeting) -> None:
         """Send an immediate channel announcement if the meeting won't appear in any future digest.

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -13,6 +13,7 @@ from typing import AsyncIterator, Sequence
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy import select, func, update
+from sqlalchemy.engine import Row
 
 from .models import Base, User, Meeting, Registration, RegistrationStatus
 
@@ -167,16 +168,31 @@ class Database:
             return await s.get(User, user_id)
 
     # Registration
-    async def register(self, meeting_id: int, user_id: int) -> tuple[bool, str]:
+    async def list_confirmed_participants(self, meeting_id: int) -> Sequence[Row[tuple[Registration, User]]]:
+        """Return confirmed non-host registrations joined with user data, ordered by signup time."""
+        async with self.session() as s:
+            res = await s.execute(
+                select(Registration, User)
+                .join(User, User.id == Registration.user_id)
+                .where(
+                    Registration.meeting_id == meeting_id,
+                    Registration.status == RegistrationStatus.CONFIRMED,
+                    Registration.is_host == False,  # noqa: E712
+                )
+                .order_by(Registration.created_at.asc())
+            )
+            return res.all()
+
+    async def register(self, meeting_id: int, user_id: int) -> tuple[bool, str, str | None]:
         """Register a user for a meeting, using waitlist if full.
 
         Returns:
-            Tuple[bool, str]: Success flag and a human-readable message.
+            Tuple of (success, message, registration_status). Status is None on failure.
         """
         async with self.session() as s:
             m = await s.get(Meeting, meeting_id)
             if m is None or m.canceled_at is not None:
-                return False, "Meeting not found or canceled."
+                return False, "Meeting not found or canceled.", None
             # Check if already registered
             res = await s.execute(
                 select(Registration).where(Registration.meeting_id == meeting_id, Registration.user_id == user_id,
@@ -184,7 +200,7 @@ class Database:
             )
             existing = res.scalar_one_or_none()
             if existing:
-                return False, "You are already registered."
+                return False, "You are already registered.", None
             # Count current confirmed
             res = await s.execute(
                 select(func.count()).select_from(Registration).where(
@@ -197,8 +213,8 @@ class Database:
             s.add(reg)
             await s.commit()
             if status == RegistrationStatus.WAITLISTED:
-                return True, "Meeting is full. You are added to the waitlist."
-            return True, "Registered successfully."
+                return True, "Meeting is full. You are added to the waitlist.", status
+            return True, "Registered successfully.", status
 
     async def is_registered(self, meeting_id: int, user_id: int) -> bool:
         """Check if user has an active (confirmed or waitlisted) registration."""

--- a/main.py
+++ b/main.py
@@ -66,8 +66,14 @@ async def main_async() -> None:
         else:
             await application.bot.send_message(chat_id=channel_id, text=text, parse_mode="HTML")
 
-    # Scheduler
-    scheduler = BotScheduler(db=db, timezone=settings.tzinfo(), send_channel_card=send_channel_card)
+    # Scheduler (bot passed for host DM notifications)
+    scheduler = BotScheduler(
+        db=db,
+        timezone=settings.tzinfo(),
+        send_channel_card=send_channel_card,
+        bot=application.bot,
+        notify_threshold=settings.notify_batch_threshold,
+    )
     # Re-assign scheduler into bot_app instance so hooks work
     bot_app.scheduler = scheduler
 
@@ -75,6 +81,7 @@ async def main_async() -> None:
     announce_conf = settings.announce_config()
     scheduler.schedule_announcements(announce_conf.days, announce_conf.time_of_day, settings.announcements_channel_id)
     scheduler.schedule_daily_reminders(settings.daily_check_time_parsed(), settings.announcements_channel_id)
+    scheduler.schedule_host_notifications(settings.notify_batch_interval_minutes)
 
     # Explicit Application lifecycle to ensure an event loop exists (Python 3.12)
     await application.initialize()


### PR DESCRIPTION
## What
- Hosts can now view the current participant list for their meeting via
  a new "Участники" button in the host keyboard.
- Hosts receive a DM when someone joins or cancels:
  - Instant notification when confirmed count < NOTIFY_BATCH_THRESHOLD (default 10)
  - Batched digest every NOTIFY_BATCH_INTERVAL_MINUTES (default 30) above the threshold

## Changes
- `bot/storage.py` — `list_confirmed_participants()`, updated `register()` return (3-tuple with status)
- `bot/scheduler.py` — `on_participant_change`, `_flush_pending_notifications`, `_send_host_dm`, `schedule_host_notifications`
- `bot/handlers.py` — `cb_participants` handler, `_format_participant_list`, host keyboard split into 2 rows, notification hooks in all register/unregister paths
- `bot/config.py` / `main.py` — `NOTIFY_BATCH_THRESHOLD`, `NOTIFY_BATCH_INTERVAL_MINUTES` env vars
- `tests/` — 22 new tests (storage + scheduler)

## No DB migrations needed